### PR TITLE
[WIP, CNTR-285] Encapsulate common pub/sub logic into a shared gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in pub_sub.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# pub_sub
+# Pub/Sub
+
+This gem encapsulates the common logic for broadcasting and subscribing to events from services.
+
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'pub_sub', git: "https://#{github_auth}@github.com/westfield/pub_sub.git"
+
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install pub_sub
+
+## Usage
+
+### Configuration
+Configuration is handled with an initializer as below.
+
+```ruby
+# config/initializers/pub_sub.rb
+PubSub.configure do |config|
+  # The name of this service
+  config.service :event
+
+  # Amazon AWS credentials
+  config.aws.access_key_id = 'abc123'
+  config.aws.aws_secret_access_key = 'abc123456zyx'
+  config.aws.region = 'us-east-1' # Optional: us-east-1 is default
+
+  # Listen for messages from one or more services
+  config.subscribe_to! :store, :centre
+  # or
+  # config.subscribe_to! :store
+  # config.subscribe_to! :centre
+end
+```
+
+
+### Receiving a message
+
+PubSub will look for a handler class based on the name of the message. For example, if a message is received with the type `retailer_update`, it will look for the class `RetailerUpdate` with the method `process`. If a matching handler cannot be found, the message will be skipped.
+
+Message data is available as a hash with indifferent access within the handler with `data` variable.
+
+```ruby
+# app/events/retailer_update.rb
+class RetailerUpdate < PubSub::EventHandler
+  def process
+  	retailer = Retailer.find_or_initialize_by(retailer_id: data.id)
+	retailer.update(name: data.name)
+  end
+end
+
+```
+
+
+### Publishing a message
+
+Publishing a message is fairly simple. Your publisher must inherit from `PubSub::EventPublisher` and call the `publish!` method with the data you want to send.
+
+The `type` and `origin` metadata will be added automatically.
+
+```ruby
+# app/events/event_update.rb
+class EventUpdate < PubSub::EventPublisher
+  class << self
+    def publish!(event)
+      super(url: event_url(event), id: event.id)
+    end
+
+    def event_url(event)
+      "https://example.com/event/#{event.id}"
+    end
+  end
+end
+```
+
+
+### Rake tasks
+
+There are a few rake tasks made available for working with the message queues and subscriptions.
+
+* `rake pub_sub:poll` - this task will receive messages from the queue(s) and dispatch them to the appropriate handler if one can be found. It is multi-threaded with 2 threads by default, but this can be changed by setting the `WORKER_CONCURRENCY` environment variable.
+
+* `rake pub_sub:subscribe` - this task will subscribe the service to the message queues specified in the config.
+
+* `rake pub_sub:debug` - this will print out information about the state of queues, topics & subscriptions.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "pub_sub"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -1,0 +1,40 @@
+require 'aws-sdk-v1'
+require 'pub_sub/version'
+require 'pub_sub/railtie' if defined?(Rails)
+
+module PubSub
+  autoload :Configuration,  'pub_sub/configuration'
+  autoload :Queue,          'pub_sub/queue'
+  autoload :Subscriber,     'pub_sub/subscriber'
+  autoload :Publisher,      'pub_sub/publisher'
+  autoload :Message,        'pub_sub/message'
+
+  autoload :EventHandler,   'pub_sub/event_handler'
+  autoload :EventPublisher, 'pub_sub/event_publisher'
+
+  class << self
+    attr_accessor :config
+
+    def config
+      @config ||= Configuration.new
+    end
+
+    def configure
+      yield(config)
+    end
+
+    def logger
+      PubSub.config.logger
+    end
+
+    # When in development or testing, we want to use our own personalized
+    # queues. Using `development` would cause conflicts with other developers.
+    def env_suffix
+      if %w(development test).include?(Rails.env)
+        `whoami`.strip
+      else
+        Rails.env
+      end
+    end
+  end
+end

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -1,0 +1,29 @@
+module PubSub
+  class Configuration
+    attr_accessor :service_name,
+                  :subscriptions,
+                  :visibility_timeout,
+                  :logger,
+                  :aws
+
+    def initialize
+      @subscriptions = Set.new
+      @visibility_timeout = 1.hour
+      @aws = Hashie::Mash.new(
+        access_key_id: nil,
+        secret_access_key: nil,
+        region: 'us-east-1'     # Default region
+      )
+    end
+
+    def service(service_name)
+      @service_name = "#{service_name}-service"
+    end
+
+    def subscribe_to!(*service_names)
+      Array.wrap(service_names).each do |service_name|
+        @subscriptions.add(service_name)
+      end
+    end
+  end
+end

--- a/lib/pub_sub/event_handler.rb
+++ b/lib/pub_sub/event_handler.rb
@@ -1,0 +1,18 @@
+module PubSub
+  class EventHandler
+    attr_accessor :message
+
+    def initialize(message)
+      @message = message
+    end
+
+    def process
+      error_message = '`process` must be overridden in subclass'
+      fail NotImplementedError, error_message
+    end
+
+    def data
+      Hashie::Mash.new(@message['data'])
+    end
+  end
+end

--- a/lib/pub_sub/event_publisher.rb
+++ b/lib/pub_sub/event_publisher.rb
@@ -1,0 +1,24 @@
+module PubSub
+  class EventPublisher < Hashie::Mash
+    def self.publish!(data)
+      new.publish!(data)
+    end
+
+    def publish!(data)
+      merge!(
+        sender: PubSub.config.service_name,
+        type: event_type,
+        data: data
+      )
+      broadcast
+    end
+
+    def event_type
+      self.class.name.underscore
+    end
+
+    def broadcast
+      Publisher.topic.publish(to_json)
+    end
+  end
+end

--- a/lib/pub_sub/message.rb
+++ b/lib/pub_sub/message.rb
@@ -1,0 +1,37 @@
+module PubSub
+  class Message
+    attr_accessor :message
+
+    def initialize(message)
+      @message = JSON.parse(message)
+    end
+
+    def process
+      handler.process if processable?
+    end
+
+    def processable?
+      if handler.nil?
+        PubSub.logger.warning("No event handler found for #{type}.")
+        nil
+      elsif !handler.respond_to?(:process)
+        PubSub.logger.error("Event handler #{type} missing process method.")
+        nil
+      else
+        true
+      end
+    end
+
+    private
+
+    def type
+      @message['type']
+    end
+
+    def handler
+      type.camelize.constantize.new(@message)
+    rescue NameError
+      nil # No handler found
+    end
+  end
+end

--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -1,0 +1,25 @@
+module PubSub
+  class Publisher
+    include Singleton
+
+    attr_accessor :sns, :topic
+
+    def self.topic
+      instance.topic
+    end
+
+    def sns
+      @sns ||= AWS::SNS.new
+    end
+
+    def topic
+      @topic ||= sns.topics.create(topic_name)
+    end
+
+    private
+
+    def topic_name
+      "#{PubSub.config.service_name}-#{PubSub.env_suffix}"
+    end
+  end
+end

--- a/lib/pub_sub/queue.rb
+++ b/lib/pub_sub/queue.rb
@@ -1,0 +1,30 @@
+module PubSub
+  class Queue
+    attr_accessor :sqs, :queue
+
+    def self.poll!
+      new.poll!
+    end
+
+    def sqs
+      @sqs ||= AWS::SQS.new
+    end
+
+    def queue
+      @queue ||= sqs.queues.create(queue_name)
+    end
+
+    def poll!
+      timeout = PubSub.config.visibility_timeout
+      queue.poll(visibility_timeout: timeout) do |message|
+        Message.new(message.body).process
+      end
+    end
+
+    private
+
+    def queue_name
+      "#{PubSub.config.service_name}-#{PubSub.env_suffix}"
+    end
+  end
+end

--- a/lib/pub_sub/railtie.rb
+++ b/lib/pub_sub/railtie.rb
@@ -1,0 +1,18 @@
+module PubSub
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      Dir[File.join(File.dirname(__FILE__), 'tasks/*.rake')].each { |f| load f }
+    end
+
+    initializer 'pubsub_railtie.configure_rails_initialization' do
+      PubSub.config.logger = Rails.logger
+
+      # Amazon AWS configuration for SNS and SQS.
+      ::AWS.config(
+        access_key_id: PubSub.config.aws.access_key_id,
+        secret_access_key: PubSub.config.aws.secret_access_key,
+        region: PubSub.config.aws.region
+      )
+    end
+  end
+end

--- a/lib/pub_sub/subscriber.rb
+++ b/lib/pub_sub/subscriber.rb
@@ -1,0 +1,31 @@
+module PubSub
+  class Subscriber
+    attr_accessor :sns
+
+    def self.subscribe!
+      new.subscribe!
+    end
+
+    def sns
+      @sns ||= AWS::SNS.new
+    end
+
+    def subscribe!
+      PubSub.config.subscriptions.each do |service_name|
+        subscribe_to_service(service_name)
+      end
+    end
+
+    def subscribe_to_service(service_name)
+      topic_name = topic_name(service_name)
+      PubSub.logger.info("Subscribing to #{topic_name}")
+      sns.topics.create(topic_name)
+    end
+
+    private
+
+    def topic_name(service_name)
+      "#{service_name}-service-#{PubSub.env_suffix}"
+    end
+  end
+end

--- a/lib/pub_sub/tasks/debug.rake
+++ b/lib/pub_sub/tasks/debug.rake
@@ -1,0 +1,50 @@
+namespace :pub_sub do
+  namespace :debug do
+    desc 'List all PubSub debugging information.'
+    task all: :environment do
+      Rake::Task['pub_sub:debug:subscriptions'].invoke
+      puts
+      Rake::Task['pub_sub:debug:topics'].invoke
+      puts
+      Rake::Task['pub_sub:debug:queues'].invoke
+    end
+
+    desc 'List information about PubSub queues.'
+    task queues: :environment do
+      puts 'Queues: ', '----------'
+      sqs.queues.each do |queue|
+        puts " - #{queue_name(queue.arn)} with approx. " \
+             "#{queue.approximate_number_of_messages} messages"
+      end
+    end
+
+    desc 'List information about the queue subscriptions.'
+    task subscriptions: :environment do
+      puts 'Subscriptions: ', '----------'
+      sns.subscriptions.sort_by(&:endpoint).each do |subscription|
+        puts " - #{queue_name(subscription.endpoint)} is listening to " \
+             "#{subscription.topic.name}"
+      end
+    end
+
+    desc 'List information about the topics.'
+    task topics: :environment do
+      puts 'Topics: ', '----------'
+      sns.topics.each do |topic|
+        puts " - #{topic.name}"
+      end
+    end
+  end
+
+  def sqs
+    @sqs ||= AWS::SQS.new
+  end
+
+  def sns
+    @sns ||= AWS::SNS.new
+  end
+
+  def queue_name(string)
+    string.split(':').last
+  end
+end

--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -1,0 +1,26 @@
+namespace :pub_sub do
+  desc 'Poll the queue for updates'
+  task poll: :environment do
+    worker_concurrency.times.map do
+      sleep 5 # Allow things to load to avoid circular reference errors
+      Thread.new { start_poll_thread }
+    end.each(&:join)
+  end
+
+  desc 'Subscribe to the topics defined in the config'
+  task subscribe: :environment do
+    PubSub::Subscriber.subscribe!
+  end
+
+  def start_poll_thread
+    PubSub::Queue.poll!
+  rescue => e
+    PubSub.logger.error("Error polling subscriptions: #{e.inspect}")
+    PubSub.logger.error(e.backtrace)
+    retry
+  end
+
+  def worker_concurrency
+    ENV.fetch('WORKER_CONCURRENCY', 2).to_i
+  end
+end

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,0 +1,3 @@
+module PubSub
+  VERSION = '0.1.0'
+end

--- a/pub_sub.gemspec
+++ b/pub_sub.gemspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'pub_sub/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'pub_sub'
+  spec.version       = PubSub::VERSION
+  spec.authors       = ['Chris Nelson']
+  spec.email         = ['cnelson@au.westfield.com']
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
+  end
+
+  spec.summary       = 'Encapsulates common Pub/Sub logic for communication between services.'
+  spec.homepage      = 'https://www.github.com/westfield/pub_sub'
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'aws-sdk-v1'
+  spec.add_dependency 'hashie'
+  spec.add_development_dependency 'bundler', '~> 1.8'
+  spec.add_development_dependency 'rake', '~> 10.0'
+end

--- a/spec/pub_sub_spec.rb
+++ b/spec/pub_sub_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe PubSub do
+  it 'has a version number' do
+    expect(PubSub::VERSION).not_to be nil
+  end
+
+  it 'does something useful' do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'pub_sub'


### PR DESCRIPTION
This gem rolls the vast majority of pub/sub logic into one place so we can easily add pub/sub support to a service without boilerplate.

It's WIP until I've written tests.

An example of this gem in use is in the following branch of event service: https://github.com/chrisrbnelson/event_service/tree/use-pubsub-gem
