### PR TITLE
Broadcast message changes after object destroy.

### DIFF
--- a/lib/pub_sub/railties/active_record.rb
+++ b/lib/pub_sub/railties/active_record.rb
@@ -6,6 +6,7 @@ module PubSub
         klass.send :extend, ClassMethods
 
         klass.after_save :publish_changes, if: -> { changed? }
+        klass.after_destroy :publish_changes
       end
 
       module InstanceMethods

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Note: this is triggered even if the object has soft-deletes.
