### PR TITLE
Pick up default ENV vars for AWS credentials. Also, exposed queue attributes for PubSub::Queue

### DIFF
--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -46,10 +46,8 @@ module PubSub
     end
 
     def rails_env
-      return Rails.env        if defined?(Rails)
-      return ENV['RAILS_ENV'] if ENV['RAILS_ENV']
-      return ENV['RACK_ENV']  if ENV['RACK_ENV']
-      'development'
+      return Rails.env if defined?(Rails)
+      ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def stub_responses!

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -21,8 +21,8 @@ module PubSub
 
     # Configure AWS credentials and region. Omit (nil) any of the parameters to use environment defaults
     def aws(
-        key: (ENV['AWS_ACCESS_KEY_ID'] || ENV['AWS_KEY_ID']),
-        secret: (ENV['AWS_SECRET_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY']),
+        key: ENV['AWS_ACCESS_KEY_ID'],
+        secret: ENV['AWS_SECRET_ACCESS_KEY'],
         region: (ENV['AWS_REGION'] || 'us-east-1')) # TODO: Remove the hardcoded region
       ::Aws.config.update(
         credentials: Aws::Credentials.new(key, secret),

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -19,11 +19,16 @@ module PubSub
       @subscriptions[service_identifier] = messages
     end
 
-    def aws(key: nil, secret: nil, region: 'us-east-1')
+    # Configure AWS credentials and region. Omit (nil) any of the parameters to use environment defaults
+    def aws(
+        key: (ENV['AWS_ACCESS_KEY_ID'] || ENV['AWS_KEY_ID']),
+        secret: (ENV['AWS_SECRET_ACCESS_KEY'] || ENV['AWS_ACCESS_KEY']),
+        region: (ENV['AWS_REGION'] || 'us-east-1')) # TODO: Remove the hardcoded region
       ::Aws.config.update(
         credentials: Aws::Credentials.new(key, secret),
         region: region
       )
     end
+
   end
 end

--- a/lib/pub_sub/queue.rb
+++ b/lib/pub_sub/queue.rb
@@ -12,6 +12,10 @@ module PubSub
       ).attributes["QueueArn"]
     end
 
+    def queue_attributes(attribute_names)
+      sqs.get_queue_attributes(queue_url: queue_url, attribute_names: attribute_names).values.first
+    end
+
     private
 
     def sqs

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Since PubSub hides a lot of AWS stuff, it is hard to get access to debug info. I've exposed some for queues.

As for the environment variables, I noticed that requiring credentials explicitly often encourages developers to put their actual credentials in the code. While that's bad and should be handled independently, I also think that providing sensible defaults might be useful. Alternatively, I considered doing `Aws.config.update` before `PubSub.configure` is called but decided against it because then we'd be overriding prior custom Aws configuration that the client might have set.