### PR TITLE
adjust sender validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ end
 
 When PubSub receives a message, it performs a couple of checks before processing:
 
-* If the message originates from a service we haven't subscribed to, a `PubSub::ServiceUnknown` exception will be logged & raised.
 * If the message originates from a known service, but the message type is not in the list of accepted types for that service, a `PubSub::MessageTypeUnknown` exception will be logged & raised.
 
 If the message passes those validations, it will `classify` the message type and run its `process` method. Data from the message is available inside the message handler via the `data` variable.
@@ -168,7 +167,6 @@ Note you don't need any additional workers to publish, only to subscribe.
 
 There are two custom exceptions which may be raised during processing:
 
-* `PubSub::ServiceUnknown` will be raised when a message arrives but the origin service is not configured in the initializer block (via `config.subscribe_to`)
 * `PubSub::MessageTypeUnknown` will be raised if a message arrives from a configured service, but is *not* in the list of acceptable messages.
 
 ### Developing with pub_sub

--- a/lib/pub_sub/message.rb
+++ b/lib/pub_sub/message.rb
@@ -17,6 +17,11 @@ module PubSub
 
     def validate_message!
       messages = PubSub.config.subscriptions[sender]
+      if messages.nil?
+        warning = "WARN: We received a message from #{sender} but we do " \
+                'not subscribe to that service.'
+        PubSub.logger.warn(warning)
+      end
       unless messages.include?(type)
         error = "We received a message from #{sender} but it was " \
                 "of unknown type #{type}."

--- a/lib/pub_sub/message.rb
+++ b/lib/pub_sub/message.rb
@@ -17,12 +17,6 @@ module PubSub
 
     def validate_message!
       messages = PubSub.config.subscriptions[sender]
-      if messages.nil?
-        error = "We received a message from #{sender} but we do " \
-                'not subscribe to that service.'
-        fail PubSub::ServiceUnknown, error
-      end
-
       unless messages.include?(type)
         error = "We received a message from #{sender} but it was " \
                 "of unknown type #{type}."

--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -15,7 +15,7 @@ namespace :pub_sub do
   def start_poll_thread
     queue_url = PubSub::Queue.new.queue_url
     PubSub::Poller.new(queue_url, verbose?).poll
-  rescue PubSub::ServiceUnknown, PubSub::MessageTypeUnknown => e
+  rescue PubSub::MessageTypeUnknown => e
     # Skip messages when we know we're not meant to process them
     error = "Not processing message: #{e.inspect}"
     PubSub.logger.error(error)

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
This caused a problem for search service.

After investigation, I don't think trying to validate the message sender does anything other than make our logic more brittle.