### PR TITLE
Auto-subscribe before polling

### DIFF
--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -1,6 +1,6 @@
 namespace :pub_sub do
   desc 'Poll the queue for updates'
-  task poll: :environment do
+  task poll: [:environment, :subscribe] do
     worker_concurrency.times.map do
       sleep 5 # Allow things to load to avoid circular reference errors
       Thread.new { start_poll_thread }

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Currently, `rake pub_sub:poll` starts with pre-existing subscriptions. Sometimes, they are outdated and other times - missing altogether. Though we expect `rake pub_sub:subscribe` to be run before, it is often left out.
There is no good reason to do this. In fact, it will be far more helpful to auto-subscribe to make sure we always deal with the latest subscriptions whenever we start polling.