### PR TITLE
[WFAPI-1303] Changed pub_sub:debug tasks to display comprehensive and readable information

### DIFF
--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.1.8'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
The new format allows the user to filter output by a string or a region.

Examples:
```
rake pub_sub:debug:all
rake pub_sub:debug:all[search] # filter by 'search'
rake pub_sub:debug:all[search,us-east-1] # filter by 'search' and 'us-east-1' region
rake pub_sub:debug:topics[search,us-east-1] # filter by 'search' and 'us-east-1' region
rake pub_sub:debug:queues[search,us-east-1] # filter by 'search' and 'us-east-1' region
rake pub_sub:debug:subscriptions[search,us-east-1] # filter by 'search' and 'us-east-1' region
```