### PR TITLE
[WFAPI-1303] Added 'rake pub_sub:cleanup' task

### DIFF
--- a/lib/pub_sub/subscriber.rb
+++ b/lib/pub_sub/subscriber.rb
@@ -66,5 +66,19 @@ module PubSub
     def queue_url(region)
       sqs(region).create_queue(queue_name: PubSub.service_identifier).queue_url
     end
+
+    # Collects all :topics or :subscriptions for a given SNS client
+    def self.collect_all(client, collection_type)
+      elements = []
+      next_token = ""
+      loop do
+        response = client.send("list_#{collection_type}".to_sym, next_token: next_token)
+        elements.concat response.send(collection_type.to_sym)
+        next_token = response.next_token
+        break if next_token.to_s == ""
+      end
+      elements
+    end
+
   end
 end

--- a/lib/pub_sub/tasks/debug.rake
+++ b/lib/pub_sub/tasks/debug.rake
@@ -15,10 +15,10 @@ namespace :pub_sub do
       args.with_defaults(filter: nil, region: nil)
       puts 'Topics: ', '----------'
       PubSub.config.regions.each do |region|
-        next if !args[:region].blank? && region != args[:region]
+        next if args[:region].present? && region != args[:region]
         client = Aws::SNS::Client.new(region: region)
         topics = PubSub::Subscriber.collect_all(client, :topics)
-        topics.select!{|t| t.topic_arn =~ Regexp.new(args[:filter])} unless args[:filter].blank?
+        topics.select!{|t| t.topic_arn =~ Regexp.new(args[:filter])} if args[:filter].present?
         topics.each do |topic|
           puts " - #{topic.topic_arn}"
           topic = Aws::SNS::Topic.new(topic.topic_arn, client: client)
@@ -35,7 +35,7 @@ namespace :pub_sub do
       message_count_attrs = %w(ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible ApproximateNumberOfMessagesDelayed)
       puts 'Queues: ', '----------'
       PubSub.config.regions.each do |region|
-        next if !args[:region].blank? && region != args[:region]
+        next if args[:region].present? && region != args[:region]
         sqs = Aws::SQS::Client.new(region: region)
         sqs.list_queues.queue_urls.each do |url|
           next unless url =~ Regexp.new(args[:filter]) || args[:filter].blank?
@@ -54,10 +54,10 @@ namespace :pub_sub do
       args.with_defaults(filter: nil, region: nil)
       puts 'Subscriptions: ', '----------'
       PubSub.config.regions.each do |region|
-        next if !args[:region].blank? && region != args[:region]
+        next if args[:region].present? && region != args[:region]
         client = Aws::SNS::Client.new(region: region)
         subs = PubSub::Subscriber.collect_all(client, :subscriptions)
-        subs.select!{|s| s.endpoint =~ Regexp.new(args[:filter])} unless args[:filter].blank?
+        subs.select!{|s| s.endpoint =~ Regexp.new(args[:filter])} if args[:filter].present?
         subs.sort_by(&:endpoint).each do |subscription|
           puts "[#{split_name(subscription.subscription_arn)}]\t#{subscription.endpoint} is listening to #{subscription.topic_arn}"
         end

--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -12,6 +12,56 @@ namespace :pub_sub do
     PubSub::Subscriber.subscribe
   end
 
+  desc "Removes abandoned subscriptions (for this service only)"
+  task :cleanup, [:dry_run] => :environment do |t, args|
+    args.with_defaults(dry_run: true)
+    puts "Filtering by '#{PubSub.service_identifier}'"
+    unrecognized_subs = []
+    PubSub.config.regions.each do |region|
+      client = Aws::SNS::Client.new(region: region)
+      current_subs = PubSub::Subscriber.collect_all(client, :subscriptions)
+      # Ignore unrelated subscriptions
+      current_subs.select! do |subscription|
+        short_endpoint_name = subscription.endpoint.split(/:/).last
+        if PubSub.service_identifier == short_endpoint_name
+          true
+        else
+          puts "#{subscription.subscription_arn} is unrelated".light_black
+          false
+        end
+      end
+      allowed_subs = PubSub.config.subscriptions.keys
+      unrecognized_subs += current_subs.select do |subscription|
+        short_topic_name = subscription.topic_arn.split(/:/).last
+        is_allowed = allowed_subs.include? short_topic_name
+        if is_allowed
+          puts "#{subscription.subscription_arn} -> #{subscription.endpoint} is allowed".green
+        else
+          puts "#{subscription.subscription_arn} -> #{subscription.endpoint} is unrecognized".red
+        end
+        !is_allowed
+      end
+      if args[:dry_run] =~ /false/i
+        unrecognized_subs.each do |subscription|
+          sub = Aws::SNS::Subscription.new(subscription.subscription_arn, client: client)
+          puts "Deleting #{subscription.subscription_arn}".yellow
+          sub.delete
+        end
+      end
+    end
+
+    unless args[:dry_run] =~ /false/i
+      if unrecognized_subs.empty?
+        puts "All current subscriptions are correct."
+      else
+        puts "\nThe following subscriptions are invalid (run 'rake pub_sub:cleanup[false]' to delete them for real):"
+        unrecognized_subs.each do |subscription|
+          puts subscription.subscription_arn
+        end
+      end
+    end
+  end
+
   def start_poll_thread
     PubSub::Poller.new.poll
   rescue => e

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
New tasks:

`rake pub_sub:cleanup` - dry run: only print invalid subscriptions
`rake pub_sub:cleanup[false]` - deletes the invalid subscriptions

The `cleanup` task is helpful in erasing leftover subscriptions that are no longer supported by the service. Topics are not touched, even if no more subscriptions remain.