### PR TITLE
[WFAPI-1303] Added ability to publish to a specific topic

### DIFF
--- a/lib/pub_sub/message_publisher.rb
+++ b/lib/pub_sub/message_publisher.rb
@@ -1,7 +1,7 @@
 module PubSub
   module MessagePublisher
-    def publish(async: false)
-      Publisher.publish(message_json, async: async)
+    def publish(async: false, custom_topic: PubSub.service_identifier)
+      Publisher.publish(message_json, async: async, custom_topic: custom_topic)
     end
 
     def message_type

--- a/lib/pub_sub/message_publisher.rb
+++ b/lib/pub_sub/message_publisher.rb
@@ -1,7 +1,7 @@
 module PubSub
   module MessagePublisher
-    def publish(async: false, custom_topic: PubSub.service_identifier)
-      Publisher.publish(message_json, async: async, custom_topic: custom_topic)
+    def publish(async: false, topic: PubSub.service_identifier)
+      Publisher.publish(message_json, async: async, topic: topic)
     end
 
     def message_type

--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -1,28 +1,28 @@
 module PubSub
   class Publisher
     class << self
-      def publish(message, async: false, custom_topic: PubSub.service_identifier)
+      def publish(message, async: false, topic: PubSub.service_identifier)
         if async
-          publish_asynchronously(message, custom_topic)
+          publish_asynchronously(message, topic)
         else
-          publish_synchronously(message, custom_topic)
+          publish_synchronously(message, topic)
         end
       end
 
-      def publish_asynchronously(message, custom_topic)
+      def publish_asynchronously(message, topic)
         Thread.new do
-          publish_synchronously(message, custom_topic)
+          publish_synchronously(message, topic)
         end
       end
 
-      def publish_synchronously(message, topic_name)
+      def publish_synchronously(message, topic)
         Breaker.run do
-          _topic_arn = topic_arn(topic_name)
+          _topic_arn = topic_arn(topic)
           result = sns.publish(
             topic_arn: _topic_arn,
             message: message
           ).message_id
-          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] published to #{topic_name} message #{result}"
+          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] published to #{topic} message #{result}"
           result
         end
       end
@@ -33,9 +33,9 @@ module PubSub
         Aws::SNS::Client.new(region: Breaker.current_region)
       end
 
-      def topic_arn(topic_name)
+      def topic_arn(topic)
         Breaker.run do
-          sns.create_topic(name: topic_name).topic_arn
+          sns.create_topic(name: topic).topic_arn
         end
       end
 

--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -27,10 +27,6 @@ module PubSub
         end
       end
 
-      def topic_name
-        PubSub.service_identifier
-      end
-
       private
 
       def sns

--- a/lib/pub_sub/tasks/debug.rake
+++ b/lib/pub_sub/tasks/debug.rake
@@ -38,7 +38,7 @@ namespace :pub_sub do
         next if args[:region].present? && region != args[:region]
         sqs = Aws::SQS::Client.new(region: region)
         sqs.list_queues.queue_urls.each do |url|
-          next unless url =~ Regexp.new(args[:filter]) || args[:filter].blank?
+          next unless args[:filter].blank? || url =~ Regexp.new(args[:filter])
           attributes = sqs.get_queue_attributes(
             queue_url: url,
             attribute_names: message_count_attrs

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.2.1'
+  VERSION = '1.3.1'
 end

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -29,17 +29,17 @@ describe PubSub::Publisher do
 
   describe '#publish' do
     it 'should publish syncronously by default' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, custom_topic: PubSub.service_identifier)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, topic: PubSub.service_identifier)
       publisher.publish
     end
 
     it 'should publish syncronously' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, custom_topic: PubSub.service_identifier)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, topic: PubSub.service_identifier)
       publisher.publish(async: false)
     end
 
     it 'should publish asyncronously' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: true, custom_topic: PubSub.service_identifier)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: true, topic: PubSub.service_identifier)
       publisher.publish(async: true)
     end
   end
@@ -61,7 +61,7 @@ describe PubSub::Publisher do
       end
       expect_any_instance_of(Aws::SNS::Client).to receive(:publish) { publish_result }
       expect(PubSub::Publisher).to receive(:topic_arn).with(:test)
-      CustomUpdate.new.publish(async: false, custom_topic: :test)
+      CustomUpdate.new.publish(async: false, topic: :test)
     end
   end
 end

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 describe PubSub::Publisher do
   before do
+    %w(info debug error warn).each do |method|
+      allow(PubSub).to receive_message_chain("logger.#{method}").and_return(anything())
+    end
     PubSub.configure do |config|
       config.service 'test'
       config.subscribe_to 'test', messages: ['example']
@@ -26,18 +29,39 @@ describe PubSub::Publisher do
 
   describe '#publish' do
     it 'should publish syncronously by default' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: false)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, custom_topic: PubSub.service_identifier)
       publisher.publish
     end
 
     it 'should publish syncronously' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: false)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: false, custom_topic: PubSub.service_identifier)
       publisher.publish(async: false)
     end
 
     it 'should publish asyncronously' do
-      expect(PubSub::Publisher).to receive(:publish).with(message, async: true)
+      expect(PubSub::Publisher).to receive(:publish).with(message, async: true, custom_topic: PubSub.service_identifier)
       publisher.publish(async: true)
+    end
+  end
+
+  describe '#topic_name' do
+    class CustomUpdate
+      include PubSub::MessagePublisher
+      def message_data
+        {}
+      end
+    end
+    let(:publish_result) { double(message_id: nil) }
+
+    it 'can be overridden' do
+      PubSub.configure do |config|
+        config.service 'publisher-test'
+        config.subscribe_to 'something', messages: ['example_update']
+        config.aws
+      end
+      expect_any_instance_of(Aws::SNS::Client).to receive(:publish) { publish_result }
+      expect(PubSub::Publisher).to receive(:topic_arn).with(:test)
+      CustomUpdate.new.publish(async: false, custom_topic: :test)
     end
   end
 end


### PR DESCRIPTION
Previously, there was no way to specify the destination topic (if anything other than "self" was desired). No longer.