### PR TITLE
[WFAPI-1537] Dropped multi-region support from circuit breaker

### DIFF
--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -55,7 +55,7 @@ module PubSub
     end
 
     def report_error(e)
-      logger.error e
+      logger.error "#{e.inspect}\n#{e.backtrace.join('\n')}"
       NewRelic::Agent.notice_error(e) if defined?(NewRelic)
     end
 

--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -54,6 +54,11 @@ module PubSub
       ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
+    def report_error(e)
+      logger.error e
+      NewRelic::Agent.notice_error(e) if defined?(NewRelic)
+    end
+
     def stub_responses!
       Aws.config[:stub_responses] = true
     end

--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -54,8 +54,8 @@ module PubSub
       ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
-    def report_error(e)
-      logger.error "#{e.inspect}\n#{e.backtrace.join('\n')}"
+    def report_error(e, extra_message = nil)
+      logger.error "#{e} - #{extra_message}\n#{e.backtrace.join("\n")}"
       NewRelic::Agent.notice_error(e) if defined?(NewRelic)
     end
 

--- a/lib/pub_sub/breaker.rb
+++ b/lib/pub_sub/breaker.rb
@@ -2,9 +2,9 @@ require 'thread'
 
 module PubSub
   class Breaker
-    NUM_ERRORS_THRESHOLD = 50
-    REENABLE_AFTER = 60
-    ERROR_WINDOW = 60
+    NUM_ERRORS_THRESHOLD = 10
+    REENABLE_AFTER = 60 # seconds
+    ERROR_WINDOW = 60 # seconds
     @@semaphore = Mutex.new
 
     class << self

--- a/lib/pub_sub/breaker.rb
+++ b/lib/pub_sub/breaker.rb
@@ -1,66 +1,55 @@
-# This is a circuit breaker that fails over to a different region on errors
+require 'thread'
+
 module PubSub
-
   class Breaker
-
-    THREAD_LOCAL_IDENTIFIER = :pub_sub_region
+    NUM_ERRORS_THRESHOLD = 50
+    REENABLE_AFTER = 60
+    ERROR_WINDOW = 60
+    @@semaphore = Mutex.new
 
     class << self
 
-      def run(&block)
-        current_breaker.run do
+      def execute(&block)
+        get_breaker.run do
           begin
             block.call
           rescue Exception => e
-            PubSub.logger.warn e
-            NewRelic::Agent.notice_error(e) if defined?(NewRelic)
-            raise # will be caught by the breaker
+            # Intercept for breaker's tracking purposes
+            PubSub.report_error e
+            raise # will be caught by the breaker once enough of these accumulate
           end
         end
       rescue CB2::BreakerOpen => e
-        PubSub.logger.warn "#{current_breaker.inspect} is open. #{e.message}"
-        Breaker.use_next_breaker
-        # Sleep to stop wasting system resources in the case where _all_ regions are down.
-        sleep 5
-        retry
+        PubSub.report_error e
+        on_breaker_open
       end
 
-      def current_breaker
-        all_breakers[current_breaker_idx]
-      end
 
-      def current_region
-        all_regions[current_breaker_idx]
-      end
+    protected
 
-      def use_next_breaker
-        Thread.current[THREAD_LOCAL_IDENTIFIER] = (Thread.current[THREAD_LOCAL_IDENTIFIER] + 1) % all_breakers.count
-        PubSub.logger.info "Switched to #{current_breaker.inspect}"
-      end
-
-      private
-
-      def current_breaker_idx
-        Thread.current[THREAD_LOCAL_IDENTIFIER] ||= 0
-      end
-
-      def all_breakers
-        @breakers ||= all_regions.map do |region|
-          CB2::Breaker.new(
-          service: "aws-#{region}-breaker",
-          duration: 60,
-          threshold: 50,
-          reenable_after: 60,
-          redis: Redis.current)
+      # Override to return the desired instance
+      def get_breaker
+        region = PubSub.config.current_region
+        @@semaphore.synchronize do
+          @@current_breaker ||= new_breaker(region)
         end
       end
 
-      def all_regions
-        PubSub.config.regions
+      # Override to provide alternative implementation.
+      def on_breaker_open
+        PubSub.logger.info "#{@@current_breaker} detected more than #{NUM_ERRORS_THRESHOLD} errors\
+         during last #{ERROR_WINDOW} seconds. Will pause execution for #{REENABLE_AFTER} seconds"
+      end
+
+      def new_breaker(region)
+        CB2::Breaker.new(
+          service: "aws-#{region}-breaker",
+          duration: ERROR_WINDOW,
+          threshold: NUM_ERRORS_THRESHOLD,
+          reenable_after: REENABLE_AFTER,
+          redis: Redis.current)
       end
 
     end
-
   end
-
 end

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -14,7 +14,7 @@ module PubSub
       @subscriptions = {}
       @topics = {}
       # How long to wait before retrying a failed message
-      @visibility_timeout = 3600 # seconds, 1 hour
+      @visibility_timeout = 1200 # seconds, 20 minutes
     end
 
     def service(service_name)

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -9,6 +9,8 @@ module PubSub
                   :logger,
                   :regions
 
+    SUPPORTED_REGIONS = %w(us-east-1 us-west-1 eu-west-1 ap-southeast-1)
+
     def initialize
       @subscriptions = {}
       @topics = {}
@@ -42,8 +44,8 @@ module PubSub
     # Configure AWS credentials and region. Omit (nil) any of the parameters to use environment defaults
     def aws(key: ENV['AWS_ACCESS_KEY_ID'],
         secret: ENV['AWS_SECRET_ACCESS_KEY'],
-        regions: %w(us-east-1 us-west-1 eu-west-1 ap-southeast-1)
-        )
+        regions: SUPPORTED_REGIONS)
+      raise(ArgumentError, "Invalid region(s): #{regions-ALLOWED_REGIONS}") if (regions-SUPPORTED_REGIONS).present?
       @regions = regions
       ::Aws.config.update(
         credentials: Aws::Credentials.new(key, secret)

--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -5,7 +5,6 @@ module PubSub
                   :subscriptions,
                   :topics,
                   :visibility_timeout,
-                  :idle_timeout,
                   :logger,
                   :regions
 
@@ -16,12 +15,14 @@ module PubSub
       @topics = {}
       # How long to wait before retrying a failed message
       @visibility_timeout = 3600 # seconds, 1 hour
-      # How long to wait before listening on another region
-      @idle_timeout = 60 # seconds
     end
 
     def service(service_name)
       @service_name = service_name.to_s
+    end
+
+    def current_region
+      regions.first
     end
 
     # Subscribe to a specific sender for specific message types.
@@ -44,12 +45,11 @@ module PubSub
     # Configure AWS credentials and region. Omit (nil) any of the parameters to use environment defaults
     def aws(key: ENV['AWS_ACCESS_KEY_ID'],
         secret: ENV['AWS_SECRET_ACCESS_KEY'],
-        regions: SUPPORTED_REGIONS)
+        regions: ['us-east-1'])
       raise(ArgumentError, "Invalid region(s): #{regions-ALLOWED_REGIONS}") if (regions-SUPPORTED_REGIONS).present?
+      raise(ArgumentError, "Only 1 region at a time is currently supported") if regions.size > 1
       @regions = regions
-      ::Aws.config.update(
-        credentials: Aws::Credentials.new(key, secret)
-      )
+      ::Aws.config.update(credentials: Aws::Credentials.new(key, secret))
     end
 
   end

--- a/lib/pub_sub/poller.rb
+++ b/lib/pub_sub/poller.rb
@@ -5,19 +5,16 @@ module PubSub
 
     # Poll for messages across all regions
     def poll
-      loop do
-        Breaker.run do
-          poller.poll(config) do |message|
-            PubSub.logger.debug "PubSub [#{PubSub.config.service_name}, #{queue_url}] received: #{message}"
-            begin
-              Message.new(message.body).process
-            rescue Faraday::TimeoutError => e
-              PubSub.logger.warn "#{e.message}. Message #{message.inspect} will be retried later"
-              throw :skip_delete
-            end
+      Breaker.execute do
+        poller.poll(config) do |message|
+          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] received: #{message}"
+          begin
+            Message.new(message.body).process
+          rescue Faraday::TimeoutError => e
+            PubSub.logger.warn "#{e.message}. Message #{message.inspect} will be retried later"
+            throw :skip_delete
           end
         end
-        Breaker.use_next_breaker
       end
     end
 
@@ -26,20 +23,12 @@ module PubSub
     def config
       {
         visibility_timeout: PubSub.config.visibility_timeout,
-        idle_timeout: PubSub.config.idle_timeout,
       }
-    end
-    
-    def queue_url
-      PubSub::Queue.new.queue_url
     end
 
     def poller
-      Aws::SQS::QueuePoller.new(queue_url, client: client)
-    end
-
-    def client
-      Aws::SQS::Client.new(region: Breaker.current_region)
+      q = PubSub::Queue.new(region: PubSub.config.current_region)
+      Aws::SQS::QueuePoller.new(q.queue_url, client: q.sqs)
     end
 
   end

--- a/lib/pub_sub/poller.rb
+++ b/lib/pub_sub/poller.rb
@@ -7,7 +7,7 @@ module PubSub
     def poll
       Breaker.execute do
         poller.poll(config) do |message|
-          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] received: #{message}"
+          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] received from #{@queue.queue_url}: #{message}"
           begin
             Message.new(message.body).process
           rescue Faraday::TimeoutError => e
@@ -27,8 +27,8 @@ module PubSub
     end
 
     def poller
-      q = PubSub::Queue.new(region: PubSub.config.current_region)
-      Aws::SQS::QueuePoller.new(q.queue_url, client: q.sqs)
+      @queue = PubSub::Queue.new(region: PubSub.config.current_region)
+      Aws::SQS::QueuePoller.new(@queue.queue_url, client: @queue.sqs)
     end
 
   end

--- a/lib/pub_sub/poller.rb
+++ b/lib/pub_sub/poller.rb
@@ -7,11 +7,11 @@ module PubSub
     def poll
       Breaker.execute do
         poller.poll(config) do |message|
-          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] received from #{@queue.queue_url}: #{message}"
+          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] received message #{message.inspect}"
           begin
             Message.new(message.body).process
           rescue Faraday::TimeoutError => e
-            PubSub.logger.warn "#{e.message}. Message #{message.inspect} will be retried later"
+            PubSub.report_error e, "Message #{message.inspect} will be retried later"
             throw :skip_delete
           end
         end

--- a/lib/pub_sub/poller.rb
+++ b/lib/pub_sub/poller.rb
@@ -17,7 +17,7 @@ module PubSub
             end
           end
         end
-        Breaker.use_next_breaker # TODO: What is this here for? Doesn't Breaker.run already loop?
+        Breaker.use_next_breaker
       end
     end
 

--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -22,7 +22,7 @@ module PubSub
             topic_arn: _topic_arn,
             message: message
           ).message_id
-          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] published to #{topic} message #{result}"
+          PubSub.logger.debug "PubSub [#{PubSub.config.service_name}] published to #{_topic_arn} message #{result}"
           result
         end
       end

--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -16,7 +16,7 @@ module PubSub
       end
 
       def publish_synchronously(message, topic)
-        Breaker.run do
+        Breaker.execute do
           _topic_arn = topic_arn(topic)
           result = sns.publish(
             topic_arn: _topic_arn,
@@ -30,11 +30,11 @@ module PubSub
       private
 
       def sns
-        Aws::SNS::Client.new(region: Breaker.current_region)
+        Aws::SNS::Client.new(region: PubSub.config.current_region)
       end
 
       def topic_arn(topic)
-        Breaker.run do
+        Breaker.execute do
           sns.create_topic(name: topic).topic_arn
         end
       end

--- a/lib/pub_sub/subscriber.rb
+++ b/lib/pub_sub/subscriber.rb
@@ -15,7 +15,7 @@ module PubSub
     private
 
     def self.critical_section(&block)
-      @@semaphore.lock(:pubsub_subscribe, SUBSCRIBE_TIMEOUT) do
+      @@semaphore.lock!(:pubsub_subscribe, SUBSCRIBE_TIMEOUT) do
         yield
       end
     end

--- a/lib/pub_sub/subscriber.rb
+++ b/lib/pub_sub/subscriber.rb
@@ -8,7 +8,7 @@ module PubSub
 
     def self.subscribe
       critical_section do
-        new.subscribe
+        new.send(:subscribe)
       end
     end
 

--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -2,10 +2,9 @@ namespace :pub_sub do
   desc 'Poll the queue for updates'
   task poll: [:environment, :subscribe] do
     worker_concurrency.times.map do |idx|
-      # Give each thread some time to load to avoid circular reference errors (class-loading is not threadsafe)
-      # [FIXME] ^ (written by a previous developer) likely refers to Breaker, though I still am not convinced there is a race condition.
-      sleep idx*5
-      Thread.new { start_poll_thread }
+      Thread.new do
+        start_poll_thread
+      end
     end.each(&:join)
   end
 
@@ -17,13 +16,13 @@ namespace :pub_sub do
   def start_poll_thread
     PubSub::Poller.new.poll
   rescue => e
-    NewRelic::Agent.notice_error(e) if defined?(NewRelic)
-    PubSub.logger.error("Unknown error polling subscriptions: #{e.inspect}\n#{e.backtrace}")
+    # Unexpected error during poll. Report and retry.
+    PubSub.report_error(e)
     retry
   end
 
   # How many threads to use for workers
   def worker_concurrency
-    ENV.fetch('PUB_SUB_WORKER_CONCURRENCY', 2).to_i
+    ENV.fetch('PUB_SUB_WORKER_CONCURRENCY', 4).to_i
   end
 end

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.3.8'
+  VERSION = '1.4.0'
 end

--- a/pub_sub.gemspec
+++ b/pub_sub.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis', '~> 3.2'
   spec.add_dependency 'faraday'
   spec.add_dependency 'colorize'
+  spec.add_dependency 'redlock'
 
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/poller_spec.rb
+++ b/spec/poller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PubSub::Poller do
 
   let(:message) do
-    double(body: JSON.dump({
+    double(message_id: '123', attributes: {a: 1}, body: JSON.dump({
       sender: "test-service-#{PubSub.env_suffix}",
       type: 'example_update',
       data: {

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 require 'thread'
 require 'redlock'
 
-describe "Subscriber" do # cannot use PubSub::Subscriber here due to 
+# cannot use PubSub::Subscriber here because it would be evaluated before
+# our overrides for Redlock below are processed
+describe "PubSub::Subscriber" do
 
   let(:semaphore) { Mutex.new }
 

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'thread'
+
+describe PubSub::Subscriber do
+
+  let(:semaphore) { Mutex.new }
+
+  before do
+    %w(info debug error warn).each do |method|
+      allow(PubSub.config).to receive_message_chain("logger.#{method}").and_return(anything())
+    end
+    PubSub.configure do |config|
+      config.aws
+    end
+    # Replace the underlying Redlock which does not work in test environment
+    allow(described_class).to receive(:critical_section) do |&block|
+      semaphore.synchronize do
+        block.call
+      end
+    end
+  end
+
+  describe '#subscribe' do
+    it 'should be thread-safe' do
+      limit = 10
+      counter = 0
+      allow_any_instance_of(described_class).to receive(:subscribe) do
+        # introduce race conditions on purpose - PubSub::Subscriber.subscribe should protect against that
+        old_value = counter
+        sleep rand
+        counter = old_value + 1
+      end
+      limit.times.map do |i|
+        Thread.new do
+          PubSub::Subscriber.subscribe
+        end
+      end.each(&:join)
+      expect(counter).to eq(limit)
+    end
+  end
+end

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 require 'thread'
+require 'redlock'
 
-describe PubSub::Subscriber do
+describe "Subscriber" do # cannot use PubSub::Subscriber here due to 
 
   let(:semaphore) { Mutex.new }
 
@@ -25,7 +26,7 @@ describe PubSub::Subscriber do
     it 'should be thread-safe' do
       limit = 10
       counter = 0
-      allow_any_instance_of(described_class).to receive(:subscribe) do
+      allow_any_instance_of(PubSub::Subscriber).to receive(:subscribe) do
         # introduce race conditions on purpose - PubSub::Subscriber.subscribe should protect against that
         old_value = counter
         sleep rand

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -13,12 +13,12 @@ describe PubSub::Subscriber do
       config.aws
     end
     # Replace the underlying Redlock which does not work in test environment
-    allow(described_class).to receive(:critical_section) do |&block|
+    allow_any_instance_of(Redlock::Client).to receive(:initialize).and_return(anything())
+    allow_any_instance_of(Redlock::Client).to receive(:lock!).with(any_args) do |&block|
       semaphore.synchronize do
         block.call
       end
     end
-    allow(Redlock::Client).to receive(:new).and_return(anything())
   end
 
   describe '#subscribe' do

--- a/spec/subscriber_spec.rb
+++ b/spec/subscriber_spec.rb
@@ -18,6 +18,7 @@ describe PubSub::Subscriber do
         block.call
       end
     end
+    allow(Redlock::Client).to receive(:new).and_return(anything())
   end
 
   describe '#subscribe' do


### PR DESCRIPTION
Key changes:
- circuit breaker no longer switches regions
- if there is a repeating error, breaker is opened and kept opened until timeout expires
- subscribing is now protected against race conditions across processes and threads
- renamed `Breaker.run` to `Breaker.execute` to distinguish `PubSub`'s method from that of `CB2`
- increased default number of polling threads from 2 to 4