### PR TITLE
Add support for rails <5.1

### DIFF
--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end

--- a/pub_sub.gemspec
+++ b/pub_sub.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk', '~> 2'
-  spec.add_dependency 'activesupport', '~> 4.2'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 5.1'
   spec.add_dependency 'cb2', '~> 0.0.3'
   spec.add_dependency 'redis', '~> 3.2'
   spec.add_dependency 'faraday'


### PR DESCRIPTION
Loosen `activesupport` dependency version to allow support for rails <5.1