### PR TITLE
[WFAPI-3117] Add pubsub message type when logging outgoing messages

### DIFF
--- a/lib/pub_sub/publisher.rb
+++ b/lib/pub_sub/publisher.rb
@@ -22,7 +22,17 @@ module PubSub
             topic_arn: _topic_arn,
             message: message
           ).message_id
-          PubSub.logger.log "PubSub [#{PubSub.config.service_name}] published to #{_topic_arn} message #{result}"
+
+          message_type = JSON.parse(message)['type'] rescue "unknown"
+
+          logging_details = {
+            service_name: PubSub.config.service_name,
+            message_type: message_type,
+            message_id: result,
+            topic_arn: _topic_arn
+          }.to_json
+
+          PubSub.logger.log "[PubSub] published message: #{logging_details}"
           result
         end
       end
@@ -38,7 +48,6 @@ module PubSub
           sns.create_topic(name: topic).topic_arn
         end
       end
-
     end
   end
 end

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.4.5'
+  VERSION = '1.4.6'
 end

--- a/spec/lib/pub_sub/publisher_spec.rb
+++ b/spec/lib/pub_sub/publisher_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+RSpec.describe PubSub::Publisher do
+  let(:message) {{ message_payload: "data goes here", type: "parking_exit_notification" }.to_json}
+
+  subject { described_class.publish(message) }
+
+  describe "#publish" do
+    it "publishes a message synchronously by default" do
+      expect(described_class)
+        .to receive(:publish_synchronously).with(message, anything)
+      described_class.publish(message)
+    end
+
+    context "when async: true is passed as a parameter" do
+      it "publishes a message asynchronously" do
+        expect(described_class)
+          .to receive(:publish_asynchronously).with(message, anything)
+        described_class.publish(message, async: true)
+      end
+    end
+  end
+
+  describe "#publish_synchronously" do
+    let(:logger) { double.as_null_object }
+    let(:sns) { double(:sn) }
+    let(:topic_arn) { "topic:arn:goes:here" }
+    let(:pub_sub_config) do
+      double(:pub_sub_config, service_name: "some-service", current_region: "us-east",
+                              logger: logger)
+    end
+    before do
+      allow(PubSub).to receive(:config).and_return(pub_sub_config)
+      allow(Aws::SNS::Client).to receive(:new).and_return(sns)
+      allow(PubSub::Breaker).to receive(:execute).and_yield
+      allow(sns).to receive(:create_topic).and_return(double(:topic, topic_arn: topic_arn))
+      allow(sns).to receive(:publish).and_return(double(message_id: "some-message-id"))
+    end
+
+    it "publishes a message" do
+      expect(sns).to receive(:publish).and_return(double(message_id: "some-message-id"))
+      described_class.publish_synchronously(message, "some topic")
+    end
+
+    it "looks up the topic_arn for the given topic" do
+      expect(sns).to receive(:create_topic).with(name: "some topic")
+      described_class.publish_synchronously(message, "some topic")
+    end
+
+    it "publishes a message with the given topic_arn" do
+      expect(sns).to receive(:publish).with(hash_including(topic_arn: "topic:arn:goes:here"))
+      described_class.publish_synchronously(message, "some topic")
+    end
+
+    it "logs the message details" do
+      expected_logging_details = %([PubSub] published message: {) +
+                                 %("service_name":"some-service",) +
+                                 %("message_type":"parking_exit_notification",) +
+                                 %("message_id":"some-message-id",) +
+                                 %("topic_arn":"topic:arn:goes:here"})
+      expect(logger).to receive(:log).with(expected_logging_details)
+      described_class.publish_synchronously(message, "some topic")
+    end
+
+    context "when the message cannot be parsed" do
+      let(:message) { "some string" }
+      it "logs an unknown message type in the message details" do
+        expected_logging_details = %([PubSub] published message: {) +
+                                   %("service_name":"some-service",) +
+                                   %("message_type":"unknown",) +
+                                   %("message_id":"some-message-id",) +
+                                   %("topic_arn":"topic:arn:goes:here"})
+        expect(logger).to receive(:log).with(expected_logging_details)
+        described_class.publish_synchronously(message, "some topic")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue:
[WFAPI-3117](https://jira.westfieldlabs.com/browse/WFAPI-3117)

### Proposed Changes:
This PR adds a `message_type` field to the logging details when publishing a message and reformats the logging data as a JSON payload to make it easier to search using Splunk.  It also adds a spec file for `PubSub::Publisher`, since one didn't previously exist.

**Before Change**

```ruby
PubSub [parking] published to arn:aws:sns:us-east-1:717362228064:parking-service-uat 
message 7f62eca6-b65c-51a9-add5-bc2c62100f20
```

**After change**

```ruby
[PubSub] published message: 
{
  "service_name":"parking",
  "message_type":"parking_registered_notification",
  "message_id":"7f62eca6-b65c-51a9-add5-bc2c62100f20",
  "topic_arn":"arn:aws:sns:us-east-1:717362228064:parking-service-uat"
}
```

This `message_type` helps during debugging because it allows us to confirm that a specific message type has been sent.

### Impact:
After this PR has been merged, the following services will be updated to use this new version:

- [payment-service](https://github.com/westfield/payment_service)
- [people-access-service](https://github.com/westfield/people_access_service)
- [messaging-service](https://github.com/westfield/messaging-service)
- [parking-service](https://github.com/westfield/parking-service)


cc: @jonatasrancan @adbatista @ashoda 

