### PR TITLE
[WFAPI-3222] Initialize handler classes early

### DIFF
--- a/lib/pub_sub/message.rb
+++ b/lib/pub_sub/message.rb
@@ -56,10 +56,9 @@ module PubSub
       @payload['data']
     end
 
-    # Guess the handler based on conventions
-    # Eg deal_update -> DealUpdate
+    # Handler class constant for this message
     def handler
-      @handler ||= type.camelize.constantize
+      PubSub.config.handlers[type]
     end
   end
 end

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.4.6'
+  VERSION = '1.4.7'
 end

--- a/spec/breaker_spec.rb
+++ b/spec/breaker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PubSub::Breaker do
+RSpec.describe PubSub::Breaker do
 
   before do
     %w(info debug error warn).each do |method|

--- a/spec/lib/pub_sub/configuration_spec.rb
+++ b/spec/lib/pub_sub/configuration_spec.rb
@@ -1,12 +1,38 @@
 require 'spec_helper'
 
 RSpec.describe PubSub::Configuration do
-  let(:logger) { double("Logger") }
+  let(:logger) { double('Logger') }
 
-  describe "#logger=" do
-    it "wraps into PubSub::Logger" do
+  describe '#logger=' do
+    it 'wraps into PubSub::Logger' do
       subject.logger = logger
       expect(subject.logger).to be_a PubSub::Logger
     end
   end
+
+  describe '#subscribe_to' do
+    it 'subscribes to all given services' do
+      class Test1Update
+      end
+      class Test1Delete
+      end
+      class Test2Update
+      end
+
+      PubSub.configure do |config|
+        config.subscribe_to 'test1', messages: ['test1_update', 'test1_delete']
+        config.subscribe_to 'test2', messages: ['test2_update']
+      end
+
+      handlers =
+        {
+          'test1_update' => Test1Update,
+          'test1_delete' => Test1Delete,
+          'test2_update' => Test2Update
+        }
+
+      expect(PubSub.config.handlers).to eq(handlers)
+    end
+  end
+
 end

--- a/spec/lib/pub_sub/message_spec.rb
+++ b/spec/lib/pub_sub/message_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe PubSub::Message do
     %w(info debug error warn log).each do |method|
       allow(PubSub.config).to receive_message_chain("logger.#{method}").and_return(anything())
     end
+    PubSub.config.subscribe_to "Entity", messages: ["entity_update"]
   end
 
   describe '#process' do

--- a/spec/poller_spec.rb
+++ b/spec/poller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PubSub::Poller do
+RSpec.describe PubSub::Poller do
 
   let(:message) do
     double(message_id: '123', attributes: {a: 1}, body: JSON.dump({

--- a/spec/pub_sub_identifier_spec.rb
+++ b/spec/pub_sub_identifier_spec.rb
@@ -1,4 +1,6 @@
-describe PubSub do
+RSpec.describe PubSub do
+  class Example
+  end
 
   before do
     PubSub.configure do |config|

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
-describe PubSub::Publisher do
+RSpec.describe PubSub::Publisher do
+  class Example
+  end
+
   before do
     %w(info debug error warn log).each do |method|
       allow(PubSub).to receive_message_chain("logger.#{method}").and_return(anything())


### PR DESCRIPTION
The creating of handler class-constants by threads can cause a circular reference if two threads process messages concurrently. By moving the creation of the handler class-constants from the value supplied by the message at message-processing time to the values available in the configuration at initialization time causes the work to occur only once at startup and not by workers at runtime, eliminating the threading issue.