### PR TITLE
[WFAPI-3233] Use after_commit callback instead

### DIFF
--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.4.7'
+  VERSION = '1.4.8'
 end


### PR DESCRIPTION
Systems are sufficiently fast that a PubSub message can be published, received, and processed before the database finishes the commit. We've seen this particularly with `create` where the record did not yet exist when the subscriber went to access it.

The solution is to set the change status before the transaction completes, and then decide to publish or not after the commit completes.