### PR TITLE
[WFAPI-3245] Rails to eagerload before threads initialization

### DIFF
--- a/lib/pub_sub/tasks/pub_sub.rake
+++ b/lib/pub_sub/tasks/pub_sub.rake
@@ -1,6 +1,9 @@
 namespace :pub_sub do
   desc 'Poll the queue for updates'
   task poll: [:environment, :subscribe] do
+    # avoid race conditions if multiple threads load classes
+    Rails.application.eager_load!
+
     worker_concurrency.times.map do |idx|
       Thread.new do
         start_poll_thread

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.4.8'
+  VERSION = '1.4.9'
 end


### PR DESCRIPTION
### Proposed Changes:
Threads currently need to load classes lazily, including models and services. Since this is not thread safe, some exceptions are sporadically raised, presented as Circular Reference errors or NoMethod errors. 

The practical effect of this is that we lose some messages.

This PR eagerloads `/app` classes prior to thread initialization.