### PR TITLE
Add whitelisting configuration

### DIFF
--- a/lib/pub_sub/configuration.rb
+++ b/lib/pub_sub/configuration.rb
@@ -6,6 +6,7 @@ module PubSub
                   :topics,
                   :visibility_timeout,
                   :log_level,
+                  :whitelist,
                   :regions
 
 
@@ -17,6 +18,7 @@ module PubSub
       # How long to wait before retrying a failed message
       @visibility_timeout = 1200 # seconds, 20 minutes
       @handlers = {}
+      @whitelist = []
     end
 
     def service(service_name)
@@ -29,6 +31,10 @@ module PubSub
 
     def logger=(log)
       @logger = Logger.new(log)
+    end
+
+    def add_to_whitelist(sender)
+      @whitelist << sender
     end
 
     # Subscribe to a specific sender for specific message types.

--- a/lib/pub_sub/message.rb
+++ b/lib/pub_sub/message.rb
@@ -29,6 +29,7 @@ module PubSub
     end
 
     def validate_message!
+      return if PubSub.config.whitelist.include?(sender)
       messages = PubSub.config.subscriptions[sender]
       if messages.nil? || messages.empty?
         warning = "#{PubSub.config.service_name} received a message from #{sender} but no matching subscription exists for that sender. Available senders are: #{PubSub.config.subscriptions.keys}"

--- a/spec/lib/pub_sub/configuration_spec.rb
+++ b/spec/lib/pub_sub/configuration_spec.rb
@@ -24,15 +24,23 @@ RSpec.describe PubSub::Configuration do
         config.subscribe_to 'test2', messages: ['test2_update']
       end
 
-      handlers =
-        {
-          'test1_update' => Test1Update,
-          'test1_delete' => Test1Delete,
-          'test2_update' => Test2Update
-        }
+      handlers = {
+        'test1_update' => Test1Update,
+        'test1_delete' => Test1Delete,
+        'test2_update' => Test2Update
+      }
 
       expect(PubSub.config.handlers).to eq(handlers)
     end
   end
 
+  describe '#add_to_whitelist' do
+    it 'add sender to whitelist' do
+      PubSub.configure do |config|
+        config.add_to_whitelist 'sender1'
+      end
+
+      expect(PubSub.config.whitelist).to include('sender1')
+    end
+  end
 end


### PR DESCRIPTION
Right now there isn't a way to prevent validating the sender. This enables a way to bypass the check. 