### PR TITLE
[API-3485]:: PUB_SUB gem: AWS::SNS fails to publish when OS username has a '.' in it

### DIFF
--- a/lib/pub_sub.rb
+++ b/lib/pub_sub.rb
@@ -44,7 +44,7 @@ module PubSub
     # queues. Using `development` would cause conflicts with other developers.
     def env_suffix
       if %w(development test).include?(rails_env)
-        `whoami`.strip
+        sanitize_for_aws(`whoami`)
       else
         rails_env
       end
@@ -62,6 +62,10 @@ module PubSub
 
     def stub_responses!
       Aws.config[:stub_responses] = true
+    end
+
+    def sanitize_for_aws(name)
+      name.strip.gsub(/[^\w\s\-]/, '_')
     end
   end
 end

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/spec/lib/pub_sub_spec.rb
+++ b/spec/lib/pub_sub_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe PubSub do
+  describe '.sanitize_for_aws' do
+    it 'returns the string sanitized for AWS' do
+      expect(subject.sanitize_for_aws('test.westfield.com'))
+        .to eq('test_westfield_com')
+    end
+  end
+end


### PR DESCRIPTION
### Issue:
[API-3485](https://jira.westfieldlabs.com/browse/API-3485)

### Proposed Changes:
Following are the required changes:

- In ```lib/pub_sub.rb```, update the ```env_suffix``` method to use the ```sanitize_for_aws``` method to ensure only AWS allowed characters are passed

### Impact:

- Will this introduce any externally facing changes(endpoint, fields, validation, query)? **No**
- Any special deployment coordination needed(env changes, data/db migrations, etc.)? **No**
- Urgency(low, medium, high)? **Medium**

### Requirements:

- Test the behaviour in UAT after it's been merged, then add the "Tested in UAT" label.
- Test the behaviour in production if possible, then add the "Tested in Production" label

@adamcohen, @gwshaw, @kislay100 
